### PR TITLE
add org.hamcrest:hamcrest-library to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 // Define the main class for the application

--- a/src/test/java/jp/co/topgate/sugawara/web/HttpResponseMessageHeaderContentTest.java
+++ b/src/test/java/jp/co/topgate/sugawara/web/HttpResponseMessageHeaderContentTest.java
@@ -2,6 +2,7 @@ package jp.co.topgate.sugawara.web;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 

--- a/src/test/java/jp/co/topgate/sugawara/web/HttpResponseStatusLineContentTest.java
+++ b/src/test/java/jp/co/topgate/sugawara/web/HttpResponseStatusLineContentTest.java
@@ -2,6 +2,7 @@ package jp.co.topgate.sugawara.web;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**


### PR DESCRIPTION
We can use `is` method in testing code.
`is` method came from `import static org.hamcrest.Matchers.is;` statement.
`org.hamcrest.Matchers.is` is hosted by `org.hamcrest:hamcrest-library` library at build.gradle.